### PR TITLE
`xml_name_escape`: Optimize the common case by 2-3x

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,8 +37,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install codespell
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install codespell==2.1.0
       - name: Check spelling with codespell
         run: codespell --ignore-words=codespell.txt || exit 1
   misspell:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -319,7 +319,7 @@ GEM
     mini_magick (4.11.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.0)
-    minitest (5.16.1)
+    minitest (5.16.3)
     minitest-bisect (1.5.1)
       minitest-server (~> 1.0)
       path_expander (~> 1.1)

--- a/activerecord/test/cases/adapters/postgresql/timestamp_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/timestamp_test.rb
@@ -145,7 +145,7 @@ class PostgresqlTimestampFixtureTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def test_bc_timestamp
-    date = Date.new(0) - 1.week
+    date = Time.new(0) - 1.week
     Developer.create!(name: "aaron", updated_at: date)
     assert_equal date, Developer.find_by_name("aaron").updated_at
   end

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -1054,6 +1054,7 @@ class OutputSafetyTest < ActiveSupport::TestCase
     unsafe_char = ">"
     safe_char = "Á"
     safe_char_after_start = "3"
+    starting_with_dash = "-foo"
 
     assert_equal "_", ERB::Util.xml_name_escape(unsafe_char)
     assert_equal "_#{safe_char}", ERB::Util.xml_name_escape(unsafe_char + safe_char)
@@ -1074,6 +1075,8 @@ class OutputSafetyTest < ActiveSupport::TestCase
     common_dangerous_chars = "&<>\"' %*+,/;=^|"
     assert_equal "_" * common_dangerous_chars.size,
                  ERB::Util.xml_name_escape(common_dangerous_chars)
+
+    assert_equal "_foo", ERB::Util.xml_name_escape(starting_with_dash)
   end
 end
 

--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -125,7 +125,7 @@ end
 When used alone, `belongs_to` produces a one-directional one-to-one connection. Therefore each book in the above example "knows" its author, but the authors don't know about their books.
 To setup a [bi-directional association](#bi-directional-associations) - use `belongs_to` in combination with a `has_one` or `has_many` on the other model.
 
-`belongs_to` does not ensure reference consistency, so depending on the use case, you might also need to add a database-level foreign key constraint on the reference column, like this:
+`belongs_to` does not ensure reference consistency if `optional` is set to true, so depending on the use case, you might also need to add a database-level foreign key constraint on the reference column, like this:
 
 ```ruby
 create_table :books do |t|

--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -572,7 +572,7 @@ The new configuration allows you to conditionally implement the new behavior:
 def changed_method
   if ActiveJob.existing_behavior
     # Existing behavior
-  else 
+  else
     # New behavior
   end
 end
@@ -614,7 +614,7 @@ As a last step add the new configuration to configuration guide in
 | --------------------- | -------------------- |
 | (original)            | `true`               |
 | 7.1                   | `false`              |
-
+```
 
 ### Ignoring Files Created by Your Editor / IDE
 

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -740,7 +740,7 @@ module ApplicationTests
       assert_no_match "create_table(:users)", output
     end
 
-    def test_run_in_parallel_with_unmarshable_exception
+    def test_run_in_parallel_with_unmarshalable_exception
       exercise_parallelization_regardless_of_machine_core_count(with: :processes)
 
       file = app_file "test/fail_test.rb", <<-RUBY
@@ -762,7 +762,7 @@ module ApplicationTests
 
       output = run_test_command(file)
 
-      assert_match(/RuntimeError: (Wrapped undumpable exception|result not reported)/, output)
+      assert_match(/RuntimeError: (Wrapped undumpable exception|result not reported|Neutered Exception)/, output)
       assert_match "1 runs, 0 assertions, 0 failures, 1 errors", output
     end
 


### PR DESCRIPTION


### Summary

This adds an early return to the method that improves the common case performance of `xml_name_escape` by 2-3x, without adding any measurable overhead to the uncommon cases (according to the benchmark below).

This came out of a conversation I had with @jhawthorn about how we could further optimize the performance of `xml_name_escape`, which is a hot path for view rendering.

### Other Information

Benchmark results:

```
============================ Common tag name short =============================

Warming up --------------------------------------
     xml_name_escape   160.032k i/100ms
fast_xml_name_escape   344.432k i/100ms
Calculating -------------------------------------
     xml_name_escape      1.621M (± 4.3%) i/s -      8.162M in   5.046212s
fast_xml_name_escape      3.361M (± 4.9%) i/s -     16.877M in   5.034697s

Comparison:
fast_xml_name_escape:  3361352.3 i/s
     xml_name_escape:  1620953.6 i/s - 2.07x  (± 0.00) slower

============================= Common tag name long =============================

Warming up --------------------------------------
     xml_name_escape    82.458k i/100ms
fast_xml_name_escape   283.361k i/100ms
Calculating -------------------------------------
     xml_name_escape    801.610k (± 6.2%) i/s -      4.040M in   5.064293s
fast_xml_name_escape      2.770M (± 4.2%) i/s -     13.885M in   5.021664s

Comparison:
fast_xml_name_escape:  2770311.7 i/s
     xml_name_escape:   801609.6 i/s - 3.46x  (± 0.00) slower

=============================== Custom tag name ================================

Warming up --------------------------------------
     xml_name_escape    75.482k i/100ms
fast_xml_name_escape   242.538k i/100ms
Calculating -------------------------------------
     xml_name_escape    749.921k (± 4.0%) i/s -      3.774M in   5.040945s
fast_xml_name_escape      2.484M (± 3.3%) i/s -     12.612M in   5.082544s

Comparison:
fast_xml_name_escape:  2484427.9 i/s
     xml_name_escape:   749921.0 i/s - 3.31x  (± 0.00) slower

========================== Custom tag name non-ascii ===========================

Warming up --------------------------------------
     xml_name_escape    65.003k i/100ms
fast_xml_name_escape    62.773k i/100ms
Calculating -------------------------------------
     xml_name_escape    665.209k (± 6.6%) i/s -      3.315M in   5.009355s
fast_xml_name_escape    630.701k (± 4.9%) i/s -      3.201M in   5.088989s

Comparison:
     xml_name_escape:   665209.5 i/s
fast_xml_name_escape:   630701.1 i/s - same-ish: difference falls within error

================================ Bad tag name 1 ================================

Warming up --------------------------------------
     xml_name_escape    41.312k i/100ms
fast_xml_name_escape    40.189k i/100ms
Calculating -------------------------------------
     xml_name_escape    396.349k (± 6.8%) i/s -      1.983M in   5.029391s
fast_xml_name_escape    381.272k (± 7.7%) i/s -      1.929M in   5.093800s

Comparison:
     xml_name_escape:   396349.4 i/s
fast_xml_name_escape:   381272.1 i/s - same-ish: difference falls within error

================================ Bad tag name 2 ================================

Warming up --------------------------------------
     xml_name_escape    15.496k i/100ms
fast_xml_name_escape    14.122k i/100ms
Calculating -------------------------------------
     xml_name_escape    161.422k (± 5.7%) i/s -    805.792k in   5.009106s
fast_xml_name_escape    160.674k (± 5.5%) i/s -    804.954k in   5.027559s

Comparison:
     xml_name_escape:   161422.2 i/s
fast_xml_name_escape:   160674.1 i/s - same-ish: difference falls within error
```

Benchmark code:

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails", branch: "main"
  gem "benchmark-ips"
end

require "active_support"
require "active_support/core_ext/string/output_safety"

class ERB
  module Util
    TAG_NAME_COMMON_CASE = /\A[a-z][a-z\-]*\z/

    def fast_xml_name_escape(name)
      name = name.to_s
      return "" if name.blank?
      return name if name.match?(TAG_NAME_COMMON_CASE)

      starting_char = name[0]
      starting_char.gsub!(TAG_NAME_START_REGEXP, TAG_NAME_REPLACEMENT_CHAR)

      return starting_char if name.size == 1

      following_chars = name[1..-1]
      following_chars.gsub!(TAG_NAME_FOLLOWING_REGEXP, TAG_NAME_REPLACEMENT_CHAR)

      starting_char << following_chars
    end
    module_function :fast_xml_name_escape
  end
end

SCENARIOS = {
  "Common tag name short" => "p",
  "Common tag name long"  => "textarea",
  "Custom tag name"       => "super-custom",
  "Custom tag name non-ascii" => "süper-custom",
  "Bad tag name 1"        => "1abc",
  "Bad tag name 2"        => "1 < 2 & 3",
}

SCENARIOS.each_pair do |name, value|
  puts
  puts " #{name} ".center(80, "=")
  puts

  Benchmark.ips do |x|
    x.report("xml_name_escape")      { ERB::Util.xml_name_escape(value) }
    x.report("fast_xml_name_escape") { ERB::Util.fast_xml_name_escape(value) }
    x.compare!
  end
end
```
